### PR TITLE
feat: Open the new article after "zenn#new_article()" called

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ After downloading to your vim runtimepath, configure your vimrc to call function
     \ "format": "%F"
     \}
 
+  " open the new article after 'zenn#new_article' with the command
+  const g:zenn#article#edit_new_cmd = "new"
+
   " npm install zenn-cli@latest
   command! -nargs=0 ZennUpdate call zenn#update()
   

--- a/autoload/zenn/article.vim
+++ b/autoload/zenn/article.vim
@@ -42,6 +42,36 @@ function! s:slug_top() abort
   endif
 endfunction
 
+function! s:edit_article(outputs) abort
+  let l:name = ''
+  if type(a:outputs) == v:t_list && len(a:outputs) == 1
+    let l:name = a:outputs[0]
+  elseif type(a:outputs) == v:t_string
+    let l:name = a:outputs
+  endif
+
+  if l:name ==# ''
+   " case-1: should not open multiple files at once
+   " case-2: if there are no file to process
+    return a:outputs
+  endif
+
+  call s:get_config().define('zenn#article', {
+        \'edit_new_cmd':v:null,
+        \})
+  let l:command = g:zenn#article#edit_new_cmd
+
+  if l:command != v:null && l:command !=# ''
+    " trim pretty-output
+    " if https://github.com/zenn-dev/zenn-editor/issues/63 accepted, it should
+    " be resolved by the option for the command 'zenn new:article'
+    let l:name = substitute(l:name, "\U1F4C4\s*\\| created\\.", '', 'g')
+    execute l:command 'articles/' . trim(l:name)
+  endif
+
+  return a:outputs
+endfunction
+
 function! zenn#article#new_article(args_dict) abort
   let l:args_dict = a:args_dict
   " create args from dict
@@ -61,4 +91,6 @@ function! zenn#article#new_article(args_dict) abort
     call extend(l:args, ['--slug', l:slug_top])
   endif
   return zenn#cmd#zenn_promise(["new:article"] + l:args)
+        \.then(
+        \  { outputs -> s:edit_article(outputs) } )
 endfunction

--- a/autoload/zenn/article.vim
+++ b/autoload/zenn/article.vim
@@ -7,7 +7,7 @@ endfunction
 
 " Check Configfunction! s:get_datetime() abort
 function! s:get_config()
-  if !exists('s:DateTime')
+  if !exists('s:Config')
     let s:Config = vital#zenn#import('Config')
   endif
   return s:Config

--- a/autoload/zenn/cmd.vim
+++ b/autoload/zenn/cmd.vim
@@ -19,8 +19,8 @@ function s:echo_promise(msg) abort
 endfunction
 " {{{1
 function s:on_receive(buffer, data) abort dict
-  " Remove trailing CRs
-  call map(a:data, 'v:val[-1:] ==# "\r" ? v:val[:-2] : v:val')
+  " Remove trailing CRs and ANSI Escape Codes
+  call map(a:data, {_, val -> substitute(v:val[-1:] ==# "\r" ? v:val[:-2] : v:val, "\x1b\\[[;0-9]*m", '', 'g')})
   call extend (a:buffer, a:data)
 endfunction
 

--- a/doc/zenn.txt
+++ b/doc/zenn.txt
@@ -12,7 +12,7 @@ Interface       |zenn-vim-interface|
 	Functions       |zenn-vim-functions|
 	Mappings        |zenn-vim-mappings|
 	Commands        |zenn-vim-commands|
-	Variables         |zenn-vim-options|
+	Variables         |zenn-vim-variables|
 
 ==============================================================================
 INTRODUCTION                                           *zenn-vim-introduction*
@@ -152,6 +152,11 @@ VARIABLES                                                 *zenn-vim-variables*
 		You should be careful to slug's length must be longer than 12 charactors.
 		See |Vital.DateTime-format| in
 		https://github.com/vim-jp/vital.vim/blob/master/doc/vital/DateTime.txt
+
+                                     *zenn-vim-variables-article-edit-new-cmd*
+	|g:zenn#article#edit_new_cmd|
+		if this is the command like "edit", "new" or "vnew",
+		zenn-vim will open the new article after "zenn#new_article".
 
                                                 *zenn-vim-variables-book-slug*
 	|g:zenn#book#slug|


### PR DESCRIPTION
- fix some bug in the out of context
  - fix: caching "vital.Config"
  - fix: trim ANSI Escape Codes from output
- implement new feature with the option "zenn#article#edit_new_cmd"
  - feat: open the new article after "zenn#new_article"
