### PR TITLE
Use "--machine-readable" option and open the bared output

### DIFF
--- a/autoload/zenn/article.vim
+++ b/autoload/zenn/article.vim
@@ -62,11 +62,7 @@ function! s:edit_article(outputs) abort
   let l:command = g:zenn#article#edit_new_cmd
 
   if l:command != v:null && l:command !=# ''
-    " trim pretty-output
-    " if https://github.com/zenn-dev/zenn-editor/issues/63 accepted, it should
-    " be resolved by the option for the command 'zenn new:article'
-    let l:name = substitute(l:name, "\U1F4C4\s*\\| created\\.", '', 'g')
-    execute l:command 'articles/' . trim(l:name)
+    execute l:command trim(l:name)
   endif
 
   return a:outputs
@@ -75,7 +71,7 @@ endfunction
 function! zenn#article#new_article(args_dict) abort
   let l:args_dict = a:args_dict
   " create args from dict
-  let l:args = []
+  let l:args = ["--machine-readable"]
   const l:slug_top = s:slug_top()
   for [key,value] in items(l:args_dict)
     call add(l:args, "--" . key)


### PR DESCRIPTION
I added the option "--machine-radable" on zenn-cli:
https://github.com/zenn-dev/zenn-editor/pull/66;

So now it can be called with that option, to parse output to get the new filename.

It'll fix: #17
